### PR TITLE
feat(web): enhance widget styling and responsiveness

### DIFF
--- a/apps/web/src/features/bitcoin/BitcoinWidget.module.css
+++ b/apps/web/src/features/bitcoin/BitcoinWidget.module.css
@@ -1,0 +1,31 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}
+
+.price {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 500;
+}
+
+@media (min-width: 640px) {
+  .price {
+    font-size: 1.5rem;
+  }
+}
+
+.updated {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+@media (prefers-color-scheme: dark) {
+  .updated {
+    color: #9ca3af;
+  }
+}

--- a/apps/web/src/features/bitcoin/BitcoinWidget.tsx
+++ b/apps/web/src/features/bitcoin/BitcoinWidget.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useEffect, useState, useCallback } from "react";
+import styles from "./BitcoinWidget.module.css";
 
 interface PriceInfo {
   price: number | null;
@@ -45,11 +46,11 @@ export const BitcoinWidget: React.FC = () => {
   }, [fetchPrice]);
 
   if (error) {
-    return <p>Error fetching price: {error}</p>;
+    return <div className={styles.container}><p>Error fetching price: {error}</p></div>;
   }
 
   if (price === null) {
-    return <p>Loading...</p>;
+    return <div className={styles.container}><p>Loading...</p></div>;
   }
 
   const formattedPrice = price.toLocaleString(undefined, {
@@ -58,9 +59,9 @@ export const BitcoinWidget: React.FC = () => {
   });
 
   return (
-    <div>
-      <p>Price: {formattedPrice}</p>
-      <p>Last update: {lastUpdated}</p>
+    <div className={styles.container}>
+      <p className={styles.price}>Price: {formattedPrice}</p>
+      <p className={styles.updated}>Last update: {lastUpdated}</p>
     </div>
   );
 };

--- a/apps/web/src/features/home/components/DashboardGrid.module.css
+++ b/apps/web/src/features/home/components/DashboardGrid.module.css
@@ -1,5 +1,17 @@
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: 1fr;
   gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }

--- a/apps/web/src/features/home/components/WidgetContainer.module.css
+++ b/apps/web/src/features/home/components/WidgetContainer.module.css
@@ -3,6 +3,29 @@
   border-radius: 8px;
   padding: 1rem;
   background: #fff;
+  height: 180px;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (min-width: 640px) {
+  .container {
+    padding: 1.25rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    padding: 1.5rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .container {
+    background: #1f2937;
+    border-color: #374151;
+    color: #f9fafb;
+  }
 }
 
 .header {
@@ -15,4 +38,23 @@
 .title {
   margin: 0;
   font-size: 1rem;
+}
+
+@media (min-width: 640px) {
+  .title {
+    font-size: 1.125rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .title {
+    font-size: 1.25rem;
+  }
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/apps/web/src/features/home/components/WidgetContainer.tsx
+++ b/apps/web/src/features/home/components/WidgetContainer.tsx
@@ -32,7 +32,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
           </Button>
         )}
       </div>
-      {children}
+      <div className={styles.content}>{children}</div>
     </div>
   );
 };

--- a/apps/web/src/features/home/routes/index.module.css
+++ b/apps/web/src/features/home/routes/index.module.css
@@ -1,5 +1,13 @@
 .container {
   max-width: 1024px;
   margin: 2rem auto;
+  padding: 0 1rem;
   font-family: Inter, system-ui, sans-serif;
+  color: #111827;
+}
+
+@media (prefers-color-scheme: dark) {
+  .container {
+    color: #f9fafb;
+  }
 }


### PR DESCRIPTION
## Summary
- refine widget container with fixed height, padding, and dark mode support
- add responsive dashboard grid and global layout tweaks
- style Bitcoin widget with consistent typography

## Testing
- `pnpm lint` *(fails: pnpm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7d5a81ac832695991c8234e325fc