### PR TITLE
feat(web): add widget interface and task list placeholder

### DIFF
--- a/apps/web/src/features/README.md
+++ b/apps/web/src/features/README.md
@@ -1,0 +1,34 @@
+# Features
+
+This directory houses dashboard widgets and related utilities.
+
+## Widget registration
+
+Widgets are small React components that can plug into the dashboard.
+Each widget implements the `WidgetProps` interface and is registered at
+runtime using `registerWidget` from `widgetRegistry.ts`.
+
+```ts
+import { registerWidget } from "./widgetRegistry";
+import { MyWidget } from "./my-widget/MyWidget";
+
+registerWidget({
+  id: "my-widget",
+  title: "My Widget",
+  render: () => <MyWidget />,
+});
+```
+
+The shared `WidgetProps` interface ensures a consistent API:
+
+```ts
+interface WidgetProps {
+  id: string;
+  title: string;
+  render: () => React.ReactNode;
+  refresh?: () => void | Promise<void>;
+}
+```
+
+Registered widgets can be retrieved with `getRegisteredWidgets()` and
+rendered by the dashboard grid.

--- a/apps/web/src/features/home/routes/index.tsx
+++ b/apps/web/src/features/home/routes/index.tsx
@@ -2,20 +2,13 @@
 import React from "react";
 import { DashboardGrid, WidgetContainer } from "../components";
 import { BitcoinWidget } from "../../bitcoin/BitcoinWidget";
+import { TaskListWidget } from "../../task-list/TaskListWidget";
+import {
+  getRegisteredWidgets,
+  registerWidget,
+  WidgetProps,
+} from "../../widgetRegistry";
 import styles from "./index.module.css";
-
-type Widget = {
-  id: string;
-  title: string;
-  render: () => React.ReactNode;
-  refresh?: () => void | Promise<void>;
-};
-
-const widgetRegistry: Widget[] = [];
-
-export const registerWidget = (widget: Widget) => {
-  widgetRegistry.push(widget);
-};
 
 registerWidget({
   id: "bitcoin-price",
@@ -23,15 +16,21 @@ registerWidget({
   render: () => <BitcoinWidget />,
 });
 
+registerWidget({
+  id: "task-list",
+  title: "Task List",
+  render: () => <TaskListWidget />,
+});
+
 export function HomeClient({ status }: { status: string }) {
-  const widgets: Widget[] = [
+  const widgets: WidgetProps[] = [
     {
       id: "api-health",
       title: "API Health",
       render: () => <p>API Health: {status}</p>,
       refresh: () => location.reload(),
     },
-    ...widgetRegistry,
+    ...getRegisteredWidgets(),
   ];
 
   return (

--- a/apps/web/src/features/task-list/TaskListWidget.tsx
+++ b/apps/web/src/features/task-list/TaskListWidget.tsx
@@ -1,0 +1,10 @@
+"use client";
+import React from "react";
+
+export const TaskListWidget: React.FC = () => (
+  <div>
+    <p>Task list coming soon...</p>
+  </div>
+);
+
+export default TaskListWidget;

--- a/apps/web/src/features/widgetRegistry.ts
+++ b/apps/web/src/features/widgetRegistry.ts
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+export interface WidgetProps {
+  id: string;
+  title: string;
+  render: () => ReactNode;
+  refresh?: () => void | Promise<void>;
+}
+
+const registry: WidgetProps[] = [];
+
+export const registerWidget = (widget: WidgetProps) => {
+  registry.push(widget);
+};
+
+export const getRegisteredWidgets = () => registry;


### PR DESCRIPTION
## Summary
- document widget registration pattern
- define WidgetProps interface and registry helper
- add placeholder Task List widget

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Unable to resolve path to module 'fastify')*

------
https://chatgpt.com/codex/tasks/task_e_68bb802421f48326aee6448fc8ff96ec